### PR TITLE
Implement plate type detection helper

### DIFF
--- a/old_tests/main_color_matching.py
+++ b/old_tests/main_color_matching.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 import sys
 from opentrons import protocol_api
+from ot2_utils import get_plate_type
 
 color_slots = ['7','8','9']
 ascii_uppercase = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
@@ -98,14 +99,7 @@ def run(protocol: protocol_api.ProtocolContext) -> None:
 
         return colors, plate, pipette, tiprack_state, off_deck_tipracks
     
-    def get_plate_type() -> str:
-        """
-        Uses the attached camera to determine the type of plate being used.
-        """
-        raise NotImplementedError
-
-    #plate_type = get_plate_type()
-    plate_type = "corning_96_wellplate_360ul_flat" # TODO: Remove this line when get_plate_type is implemented.
+    plate_type = get_plate_type()
     colors, plate, pipette, tiprack_state, off_deck_tipracks = setup(plate_type)
 
     def get_color() -> list[list[list[float]]]:

--- a/old_tests/quick_test.py
+++ b/old_tests/quick_test.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 import sys
 from opentrons import protocol_api
+from ot2_utils import get_plate_type
 
 color_slots = ['7','8','9']
 ascii_uppercase = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
@@ -63,14 +64,7 @@ def run(protocol: protocol_api.ProtocolContext) -> None:
         pipette = protocol.load_instrument('p300_single_gen2', 'left', tip_racks=tipracks)
         return colors, plate, pipette
     
-    def get_plate_type() -> str:
-        """
-        Uses the attached camera to determine the type of plate being used.
-        """
-        raise NotImplementedError
-
-    #plate_type = get_plate_type()
-    plate_type = "corning_96_wellplate_360ul_flat" # TODO: Remove this line when get_plate_type is implemented.
+    plate_type = get_plate_type()
     colors, plate, pipette = setup(plate_type)
 
     def get_color() -> list[list[list[float]]]:

--- a/remote/remote_ot2_color_learning_main.py
+++ b/remote/remote_ot2_color_learning_main.py
@@ -3,7 +3,8 @@ from pathlib import Path
 import sys
 from typing import Any, Dict, List, Tuple
 from opentrons import protocol_api
-import time 
+import time
+from ot2_utils import get_plate_type
 
 color_slots = ['4','5','6','7','8','9','10','11']
 ascii_uppercase = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
@@ -308,8 +309,7 @@ def run(protocol: protocol_api.ProtocolContext) -> None:
 
     ### MAIN PROTOCOL ###
 
-    #plate_type = get_plate_type()
-    plate_type = "corning_96_wellplate_360ul_flat" # TODO: Remove this line when get_plate_type is implemented 
+    plate_type = get_plate_type()
     global tiprack_state, run_flag, reduced_tips_info
     reduced_tips_info = None
     protocol.comment("Loading labware and instruments...")


### PR DESCRIPTION
## Summary
- add `get_plate_type()` helper that reads the calibration file
- replace TODO plate type lines in old test scripts and remote protocol
- allow `camera_w_calibration.py` to select plate type with a new CLI option

## Testing
- `python -m py_compile ot2_utils.py old_tests/quick_test.py old_tests/main_color_matching.py remote/remote_ot2_color_learning_main.py camera_w_calibration.py`
