### PR TITLE
Add initial unit tests

### DIFF
--- a/tests/test_camera_utils.py
+++ b/tests/test_camera_utils.py
@@ -1,0 +1,32 @@
+import importlib.util
+import unittest
+
+SKIP = importlib.util.find_spec("numpy") is None or importlib.util.find_spec("cv2") is None
+
+if not SKIP:
+    import numpy as np
+    from camera.camera_w_calibration import PlateProcessor, srgb2lin, lin2srgb
+
+
+@unittest.skipIf(SKIP, "numpy and cv2 are required")
+class CameraUtilsTests(unittest.TestCase):
+    def test_well_centers_shape(self):
+        centers = PlateProcessor.well_centers(0, 0, 120, 80, plate="96")
+        self.assertEqual(centers.shape, (8, 12, 2))
+
+    def test_srgb_roundtrip(self):
+        rgb = np.array([[0, 128, 255]], dtype=np.float32)
+        lin = srgb2lin(rgb)
+        out = lin2srgb(lin)
+        self.assertTrue(np.allclose(out, rgb, atol=1))
+
+    def test_avg_rgb_basic(self):
+        img = np.zeros((5, 5, 3), dtype=np.uint8)
+        img[:] = [0, 0, 255]
+        centers = np.array([[[2, 2]]], dtype=float)
+        rgb = PlateProcessor.avg_rgb(img, centers, win=3, trim=0)
+        self.assertTrue(np.allclose(rgb[0][0], [255, 0, 0]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_color_learning.py
+++ b/tests/test_color_learning.py
@@ -1,0 +1,52 @@
+import importlib.util
+import unittest
+
+SKIP = importlib.util.find_spec("numpy") is None or importlib.util.find_spec("sklearn") is None
+
+if not SKIP:
+    import numpy as np
+    from active_learning.color_learning import ColorLearningOptimizer
+
+
+@unittest.skipIf(SKIP, "numpy and sklearn are required")
+class ColorLearningTests(unittest.TestCase):
+    def test_apply_min_volume_constraint(self):
+        opt = ColorLearningOptimizer(dye_count=3, max_well_volume=100, min_required_volume=20)
+        volumes = [10, 30, 50]
+        result = opt._apply_min_volume_constraint(volumes)
+        self.assertEqual(sum(result), 100)
+        for v in result:
+            if v != 0:
+                self.assertGreaterEqual(v, opt.min_required_volume)
+
+    def test_random_combination_respects_constraints(self):
+        opt = ColorLearningOptimizer(dye_count=3, max_well_volume=200, step=10)
+        vols = opt._random_combination()
+        self.assertEqual(sum(vols), 200)
+        for v in vols:
+            self.assertEqual(v % opt.step, 0)
+            self.assertGreaterEqual(v, 0)
+            self.assertLessEqual(v, opt.max_well_volume)
+
+    def test_mlp_active_training_and_suggestion(self):
+        opt = ColorLearningOptimizer(
+            dye_count=2,
+            max_well_volume=100,
+            step=10,
+            optimization_mode="mlp_active",
+            n_models=2,
+        )
+        # simple linear mixing model: dye1 controls red, dye2 controls green
+        for v1 in range(0, 101, 50):
+            v2 = 100 - v1
+            color = [int(255 * v1 / 100), int(255 * v2 / 100), 0]
+            opt.add_data([v1, v2], color)
+
+        target = [128, 128, 0]
+        suggestion = opt.suggest_next_experiment(target)
+        self.assertEqual(len(suggestion), 2)
+        self.assertEqual(sum(suggestion), opt.max_well_volume)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ot2_utils.py
+++ b/tests/test_ot2_utils.py
@@ -1,0 +1,43 @@
+import importlib
+import sys
+import types
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+# Stub paramiko and scp so module can be imported without the packages
+paramiko_stub = types.ModuleType("paramiko")
+paramiko_stub.SSHClient = object
+paramiko_stub.AutoAddPolicy = object
+class DummyRSAKey:
+    @classmethod
+    def from_private_key_file(cls, *args, **kwargs):
+        return None
+paramiko_stub.RSAKey = DummyRSAKey
+sys.modules.setdefault("paramiko", paramiko_stub)
+
+scp_stub = types.ModuleType("scp")
+scp_stub.SCPClient = object
+sys.modules.setdefault("scp", scp_stub)
+
+ot2_utils = importlib.import_module("robot.ot2_utils")
+
+
+class OT2UtilsTests(unittest.TestCase):
+    def test_get_plate_type(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg_path = Path(tmp) / "calibration.json"
+            cfg_path.write_text(json.dumps({"plate_type": "24"}))
+            plate = ot2_utils.get_plate_type(str(cfg_path))
+            self.assertEqual(plate, "corning_24_wellplate_3.4ml_flat")
+
+    def test_get_plate_type_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            missing_path = Path(tmp) / "missing.json"
+            plate = ot2_utils.get_plate_type(str(missing_path))
+            self.assertEqual(plate, "corning_96_wellplate_360ul_flat")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `unittest` based tests for color learning optimizer
- add camera utility tests for plate processor helpers
- add OT2 utility tests with stubbed dependencies

## Testing
- `python -m unittest discover -v`