### PR TITLE
Add virtual camera mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ WetLabColorMatchingAI automates color mixing experiments on an Opentrons OT-2 ro
 - **active_learning/** – Optimizers and algorithms that decide which dye volumes
   to test next.
 - **camera/** – Camera calibration utilities and example data used to measure
-  plate colors.
+  plate colors.  The :class:`PlateProcessor` supports a ``virtual_mode`` that
+  skips the webcam and returns an all white plate for testing.
 - **robot/** – OT-2 helper functions and argument files shared by the different
   protocols.
 - **remote/** – Protocols intended to be executed directly on the OT-2.

--- a/test_new_active_learning.py
+++ b/test_new_active_learning.py
@@ -1,42 +1,52 @@
-from robot.ot2_utils import OT2Manager, TiprackEmptyError
-from camera.camera_w_calibration import PlateProcessor
-from active_learning.color_learning import ColorLearningOptimizer
+"""Manual test script for the active learning pipeline.
 
-from main_active_learning import active_learn_row
+This module is not executed during automated tests.  Its contents are wrapped
+in a ``__main__`` guard so ``unittest`` discovery does not attempt to import
+external dependencies like ``paramiko``.
+"""
 
-color_slots = ["7", "8", "9", "11"]
+if __name__ == "__main__":
+    from robot.ot2_utils import OT2Manager, TiprackEmptyError
+    from camera.camera_w_calibration import PlateProcessor
+    from active_learning.color_learning import ColorLearningOptimizer
+    from main_active_learning import active_learn_row
 
-optimizer = ColorLearningOptimizer(dye_count=len(color_slots),
-                                   tolerance=80)
+    color_slots = ["7", "8", "9", "11"]
 
+    optimizer = ColorLearningOptimizer(dye_count=len(color_slots),
+                                       tolerance=80)
 
-row = "A"
+    row = "A"
 
-robot =  OT2Manager(hostname="172.26.192.201", username="root", key_filename="secret/ot2_ssh_key_remote", password=None, reduced_tips_info=len(color_slots), virtual_mode=False)
+    robot = OT2Manager(
+        hostname="172.26.192.201",
+        username="root",
+        key_filename="secret/ot2_ssh_key_remote",
+        password=None,
+        reduced_tips_info=len(color_slots),
+        virtual_mode=False,
+    )
 
-CAM_INDEX = 2
+    CAM_INDEX = 2
 
-processor = PlateProcessor()
+    processor = PlateProcessor()
 
-# Turn on lights
-robot.add_turn_on_lights_action()
-robot.execute_actions_on_remote()
+    robot.add_turn_on_lights_action()
+    robot.execute_actions_on_remote()
 
-# Measure the plate
-measured_plate = processor.process_image(cam_index=CAM_INDEX)
+    measured_plate = processor.process_image(cam_index=CAM_INDEX)
+    target_color = measured_plate[0][0]
 
-target_color = measured_plate[0][0] # A1 RGB
+    def log_cb(msg: str) -> None:
+        print(msg)
 
-def log_cb(msg: str) -> None:
-    print(msg)
-
-active_learn_row(
-    robot=robot,
-    processor=processor,
-    optimizer=optimizer,
-    row_letter=row,
-    target_color=target_color,
-    color_slots=color_slots,
-    cam_index=CAM_INDEX,
-    log_cb=log_cb
-)
+    active_learn_row(
+        robot=robot,
+        processor=processor,
+        optimizer=optimizer,
+        row_letter=row,
+        target_color=target_color,
+        color_slots=color_slots,
+        cam_index=CAM_INDEX,
+        log_cb=log_cb,
+    )


### PR DESCRIPTION
## Summary
- add an optional `virtual_mode` flag to `PlateProcessor`
- return an all-white matrix when in virtual mode instead of capturing
- document virtual camera mode in README
- guard `test_new_active_learning` with `__main__` so unit tests don't import paramiko

## Testing
- `python -m unittest discover -v`