### PR TITLE
Add requirements file and update README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,11 @@ WetLabColorMatchingAI automates color mixing experiments on an Opentrons OT-2 ro
 
 ## Installation
 
-All scripts require Python 3. Install the main dependencies with:
+All scripts require Python 3. Install the required packages with:
 
 ```bash
-pip install paramiko scp opencv-python streamlit scikit-learn
+pip install -r requirements.txt
 ```
-
-Additional packages such as `numpy`, `matplotlib` and others that ship with
-scientific Python distributions may also be required.
 
 ## Connecting to the OT-2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+numpy
+pandas
+matplotlib
+seaborn
+opencv-python
+scikit-learn
+scipy
+streamlit
+paramiko
+scp
+opentrons


### PR DESCRIPTION
## Summary
- gather all dependencies into a `requirements.txt`
- simplify installation instructions in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*