### PR TITLE
Add baseline color tracking and robot CLI support

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests


### PR DESCRIPTION
## Summary
- compute well baseline RGB values during calibration and save in `calibration.json`
- subtract baseline colors before Macbeth correction
- optionally control OT2 robot lighting from CLI
- load OT2 info by `--robot-number` and try local IP before remote
- ensure pytest only runs tests in `tests/`
- test baseline logic via new unit test

## Testing
- `pytest -q`
