### PR TITLE
Fix baseline correction

### DIFF
--- a/camera/camera_w_calibration.py
+++ b/camera/camera_w_calibration.py
@@ -489,7 +489,13 @@ class PlateProcessor:
 
         baseline = cfg.get("baseline_colors")
         if baseline is not None:
-            raw_bs = np.clip(np.array(raw, np.float32) - np.array(baseline, np.float32), 0, None)
+            # Compute the per-well difference from the average baseline and
+            # subtract that from the raw reading.  This avoids clipping
+            # everything to blue when the baseline itself is quite bright.
+            baseline_arr = np.array(baseline, np.float32)
+            base_mean = baseline_arr.mean(axis=(0, 1), keepdims=True)
+            diff = baseline_arr - base_mean
+            raw_bs = np.clip(np.array(raw, np.float32) - diff, 0, None)
         else:
             raw_bs = np.array(raw, np.float32)
 

--- a/tests/test_camera_utils.py
+++ b/tests/test_camera_utils.py
@@ -66,6 +66,8 @@ class CameraUtilsTests(unittest.TestCase):
             calib = os.path.join(tmp, "cal.json")
             img = np.zeros((10, 10, 3), dtype=np.uint8)
             baseline = [[[1, 1, 1] for _ in range(12)] for _ in range(8)]
+            baseline[0][0] = [2, 2, 2]
+            baseline[0][1] = [0, 0, 0]
             raw_vals = [[[11, 11, 11] for _ in range(12)] for _ in range(8)]
 
             with open(snap, "wb") as f:


### PR DESCRIPTION
## Summary
- adjust baseline correction to account for well-to-well differences
- update unit test for new baseline correction behaviour

## Testing
- `pytest -q`