### PR TITLE
Add ship placement AI and automation

### DIFF
--- a/battleship/placement_ai/__init__.py
+++ b/battleship/placement_ai/__init__.py
@@ -1,0 +1,9 @@
+from .base_placement_ai import PlacementAI
+from .naive_placement_ai import NaivePlacementAI
+from .random_placement_ai import RandomPlacementAI
+
+__all__ = [
+    'PlacementAI',
+    'NaivePlacementAI',
+    'RandomPlacementAI',
+]

--- a/battleship/placement_ai/base_placement_ai.py
+++ b/battleship/placement_ai/base_placement_ai.py
@@ -1,0 +1,14 @@
+from abc import ABC, abstractmethod
+from typing import Dict, Any, Tuple, List
+
+class PlacementAI(ABC):
+    """Base class for ship placement algorithms."""
+
+    def __init__(self, board_shape: Tuple[int, int], ship_schema: Dict[str, Any]):
+        self.board_shape = board_shape
+        self.ship_schema = ship_schema
+
+    @abstractmethod
+    def generate_placement(self) -> List[Dict[str, Any]]:
+        """Return a placement schema for all ships."""
+        raise NotImplementedError

--- a/battleship/placement_ai/naive_placement_ai.py
+++ b/battleship/placement_ai/naive_placement_ai.py
@@ -1,0 +1,25 @@
+from typing import Dict, Any, Tuple, List
+from .base_placement_ai import PlacementAI
+
+class NaivePlacementAI(PlacementAI):
+    """Simple placement algorithm that packs ships row by row."""
+
+    def generate_placement(self) -> List[Dict[str, Any]]:
+        rows, cols = self.board_shape
+        placements: List[Dict[str, Any]] = []
+        current_row = 0
+        current_col = 0
+        for ship in self.ship_schema.values():
+            length = ship['length']
+            for _ in range(ship['count']):
+                if current_col + length > cols:
+                    current_row += 1
+                    current_col = 0
+                placements.append({
+                    'row': current_row,
+                    'col': current_col,
+                    'length': length,
+                    'direction': 'horizontal'
+                })
+                current_col += length + 1
+        return placements

--- a/battleship/placement_ai/random_placement_ai.py
+++ b/battleship/placement_ai/random_placement_ai.py
@@ -1,0 +1,33 @@
+import random
+from typing import Dict, Any, Tuple, List
+from .base_placement_ai import PlacementAI
+
+class RandomPlacementAI(PlacementAI):
+    """Random placement algorithm with basic collision avoidance."""
+
+    def generate_placement(self) -> List[Dict[str, Any]]:
+        rows, cols = self.board_shape
+        taken = set()
+        placements: List[Dict[str, Any]] = []
+        for ship in self.ship_schema.values():
+            length = ship['length']
+            for _ in range(ship['count']):
+                placed = False
+                for _ in range(100):
+                    direction = random.choice(['horizontal', 'vertical'])
+                    if direction == 'horizontal':
+                        row = random.randint(0, rows - 1)
+                        col = random.randint(0, cols - length)
+                        cells = {(row, col + i) for i in range(length)}
+                    else:
+                        row = random.randint(0, rows - length)
+                        col = random.randint(0, cols - 1)
+                        cells = {(row + i, col) for i in range(length)}
+                    if not (cells & taken):
+                        taken.update(cells)
+                        placements.append({'row': row, 'col': col, 'length': length, 'direction': direction})
+                        placed = True
+                        break
+                if not placed:
+                    raise RuntimeError('Failed to place ship')
+        return placements

--- a/battleship/placement_utils.py
+++ b/battleship/placement_utils.py
@@ -1,0 +1,46 @@
+from typing import List, Dict, Tuple, Any
+
+
+def validate_placement_schema(schema: List[Dict[str, Any]], board_shape: Tuple[int, int], ship_schema: Dict[str, Any]) -> bool:
+    """Validate placement schema for overlaps and bounds."""
+    rows, cols = board_shape
+    occupied = set()
+    count = 0
+    for entry in schema:
+        row = entry['row']
+        col = entry['col']
+        length = entry['length']
+        direction = entry['direction']
+        if direction not in ('horizontal', 'vertical'):
+            return False
+        if row < 0 or col < 0 or row >= rows or col >= cols:
+            return False
+        if direction == 'horizontal':
+            if col + length > cols:
+                return False
+            cells = {(row, col + i) for i in range(length)}
+        else:
+            if row + length > rows:
+                return False
+            cells = {(row + i, col) for i in range(length)}
+        if occupied & cells:
+            return False
+        occupied.update(cells)
+        count += length
+    expected = sum(s['length'] * s['count'] for s in ship_schema.values())
+    if count != expected:
+        return False
+    return True
+
+def coords_from_schema(schema: List[Dict[str, Any]]) -> List[Tuple[int, int]]:
+    coords: List[Tuple[int, int]] = []
+    for entry in schema:
+        r = entry['row']
+        c = entry['col']
+        l = entry['length']
+        d = entry['direction']
+        if d == 'horizontal':
+            coords.extend([(r, c + i) for i in range(l)])
+        else:
+            coords.extend([(r + i, c) for i in range(l)])
+    return coords

--- a/battleship/robot/ot2_utils.py
+++ b/battleship/robot/ot2_utils.py
@@ -282,6 +282,14 @@ class OT2Manager:
         """Queue a fire missile action."""
         self._add_action("fire_missile", {"plate_idx": plate_idx, "plate_well": plate_well})
 
+    def add_place_water_action(self, plate_idx: int, wells: List[str]) -> None:
+        """Queue action to place ocean water in specified wells."""
+        self._add_action("place_water_in_wells", {"plate_idx": plate_idx, "wells": wells})
+
+    def add_place_ships_action(self, plate_idx: int, wells: List[str]) -> None:
+        """Queue action to place ship fluid in specified wells."""
+        self._add_action("place_ships_in_wells", {"plate_idx": plate_idx, "wells": wells})
+
     def __del__(self) -> None:
         # Close the SSH connection when the object is deleted.
         try:


### PR DESCRIPTION
## Summary
- add generic placement AI framework with naive and random implementations
- validate ship placements
- implement new OT2 actions to dispense water and ship fluid
- support placement algorithms in Streamlit app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685abaf201f4832bb142ee8f69a28f42