### PR TITLE
Support calibration column in battleship

### DIFF
--- a/battleship/plate_state_processor.py
+++ b/battleship/plate_state_processor.py
@@ -4,17 +4,21 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from camera.camera_w_calibration import PlateProcessor
 from camera.dual_camera_w_calibration import DualPlateProcessor
 from enum import Enum
-from typing import List, Dict, Any, Tuple
+from typing import Dict, Any, Tuple
 import numpy as np
+
+
+def calibration_colors(plate: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    """Return (miss_avg, hit_avg) using column 12 of the plate."""
+    col = plate[:, 11]
+    miss_avg = col[:4].mean(axis=0)
+    hit_avg = col[4:8].mean(axis=0)
+    return miss_avg, hit_avg
 
 class WellState(Enum):
     UNKNOWN = 0
     MISS = 1
     HIT = 2
-
-class WellColor(Enum):
-    CLEAR = 0
-    RED = 1
 
 class PlateStateProcessor:
     """A class to process the state of a plate based on camera input.
@@ -30,12 +34,7 @@ class PlateStateProcessor:
         self.ot_number = ot_number
 
     def determine_well_state(self, well: Tuple[int, int]) -> WellState:
-        """Determine the state of a well based on its coordinates.
-        
-        This will either be MISS or HIT. We assume that if the AI is
-        asking for this well to be resolved, it has already been
-        targeted by the AI and thus the state is known.
-        """
+        """Determine the state of a well based on its coordinates using calibration wells."""
         i, j = well
 
         rows = int(self.plate_schema.get('rows', 0))
@@ -43,34 +42,21 @@ class PlateStateProcessor:
         if i < 0 or i >= rows or j < 0 or j >= cols:
             raise ValueError(f"Invalid well coordinates: {well}")
 
-        plate_state = self.process_plate()
+        plate_colors = self.process_plate()
+        miss_avg, hit_avg = calibration_colors(plate_colors)
 
-        well_color = plate_state[i][j]
-        if well_color == WellColor.CLEAR:
-            return WellState.HIT
-        elif well_color == WellColor.RED:
-            return WellState.MISS
-        else:
-            raise ValueError(f"Unknown well color: {well_color} at coordinates {well}")
+        color = plate_colors[i, j]
+        dist_miss = np.linalg.norm(color - miss_avg)
+        dist_hit = np.linalg.norm(color - hit_avg)
+        return WellState.MISS if dist_miss < dist_hit else WellState.HIT
 
-    def process_plate(self) -> np.ndarray[WellColor]:
-        """Process the plate image and return the measured plate as a WellColor array."""
-        raw_plate = self.processor.process_image(cam_index=self.cam_index, calib=f"secret/OT_{self.ot_number}/calibration.json")
-        return np.array([[self.determine_color(color) for color in row] for row in raw_plate])
+    def process_plate(self) -> np.ndarray:
+        """Return the measured plate colors."""
+        return self.processor.process_image(
+            cam_index=self.cam_index,
+            calib=f"secret/OT_{self.ot_number}/calibration.json",
+        )
 
-    def determine_color(self, color: Tuple[int, int, int]) -> WellColor:
-        """Determine the WellColor of a given pixel.
-        
-        Colors are determined based on RGB values. Because we are working with
-        subtractive colors, simply having a high red value is not enough to
-        determine if the well is red. We need to check if the red value is
-        significantly higher than the other two color channels.
-        """
-        r, g, b = color
-        if r > g + 20 and r > b + 20:
-            return WellColor.RED
-        else:
-            return WellColor.CLEAR
 
 class DualPlateStateProcessor:
     """A class to process the state of two plates based on camera input.
@@ -86,47 +72,30 @@ class DualPlateStateProcessor:
         self.ot_number = ot_number
 
     def determine_well_state(self, plate_id: int, well: Tuple[int, int]) -> WellState:
-        """Determine the state of a well based on its coordinates.
-        
-        This will either be MISS or HIT. We assume that if the AI is
-        asking for this well to be resolved, it has already been
-        targeted by the AI and thus the state is known.
-        """
+        """Determine the state of a well using calibration wells."""
         i, j = well
 
-        rows = int(self.plate_schema.get('rows', 0))
-        cols = int(self.plate_schema.get('columns', 0))
+        rows = int(self.plate_schema.get("rows", 0))
+        cols = int(self.plate_schema.get("columns", 0))
         if i < 0 or i >= rows or j < 0 or j >= cols:
             raise ValueError(f"Invalid well coordinates: {well}")
 
-        plate_state = self.process_plate(plate_id=plate_id)
+        plate_colors = self.process_plate(plate_id=plate_id)
+        miss_avg, hit_avg = calibration_colors(plate_colors)
 
-        well_color = plate_state[i][j]
-        if well_color == WellColor.CLEAR:
-            return WellState.HIT
-        elif well_color == WellColor.RED:
-            return WellState.MISS
-        else:
-            raise ValueError(f"Unknown well color: {well_color} at coordinates {well}")
+        color = plate_colors[i, j]
+        dist_miss = np.linalg.norm(color - miss_avg)
+        dist_hit = np.linalg.norm(color - hit_avg)
+        return WellState.MISS if dist_miss < dist_hit else WellState.HIT
 
-    def process_plate(self, plate_id: int) -> np.ndarray[WellColor]:
-        """Process the plate image and return the measured plate as a WellColor array."""
-        raw_plates = self.processor.process_image(cam_index=self.cam_index, calib=f"secret/OT_{self.ot_number}/dual_calibration.json")
-        raw_plate = raw_plates[f'plate_{plate_id}']
+    def process_plate(self, plate_id: int) -> np.ndarray:
+        """Return the measured plate colors for a given plate."""
+        raw_plates = self.processor.process_image(
+            cam_index=self.cam_index,
+            calib=f"secret/OT_{self.ot_number}/dual_calibration.json",
+        )
+        raw_plate = raw_plates[f"plate_{plate_id}"]
         if raw_plate is None:
             raise ValueError(f"No plate data found for plate ID {plate_id}")
-        return np.array([[self.determine_color(color) for color in row] for row in raw_plate])
+        return raw_plate
     
-    def determine_color(self, color: Tuple[int, int, int]) -> WellColor:
-        """Determine the WellColor of a given pixel.
-        
-        Colors are determined based on RGB values. Because we are working with
-        subtractive colors, simply having a high red value is not enough to
-        determine if the well is red. We need to check if the red value is
-        significantly higher than the other two color channels.
-        """
-        r, g, b = color
-        if r > g + 20 and r > b + 20:
-            return WellColor.RED
-        else:
-            return WellColor.CLEAR


### PR DESCRIPTION
## Summary
- restrict game logic to an 8x11 board while leaving column 12 for color calibration
- determine hits/misses by comparing shot colors with calibration wells
- preload column 12 with calibration fluids and fire missiles at those wells
- adjust placement and gameplay code to use the new board size

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685af8e096d4832ba1170a29bc075d9c