### PR TITLE
Implement continuous camera capture

### DIFF
--- a/camera/camera_stream.py
+++ b/camera/camera_stream.py
@@ -1,0 +1,53 @@
+import cv2
+import time
+import threading
+
+class CameraStream:
+    """Background camera capture."""
+    def __init__(self, cam_index: int = 0,
+                 res: tuple[int, int] | None = (1600, 1200),
+                 warm: int = 10) -> None:
+        self.cam_index = cam_index
+        self.cap = cv2.VideoCapture(cam_index, cv2.CAP_DSHOW)
+        if not self.cap.isOpened():
+            raise RuntimeError("Camera open failed")
+        if res:
+            w, h = res
+            self.cap.set(3, w)
+            self.cap.set(4, h)
+            time.sleep(0.2)
+        for _ in range(warm):
+            self.cap.read()
+            time.sleep(0.04)
+        self.frame = None
+        self.running = True
+        self.thread = threading.Thread(target=self._loop, daemon=True)
+        self.thread.start()
+
+    def _loop(self) -> None:
+        while self.running:
+            ret, frm = self.cap.read()
+            if ret:
+                self.frame = frm
+            time.sleep(0.01)
+
+    def read(self):
+        return self.frame
+
+    def stop(self) -> None:
+        self.running = False
+        self.thread.join()
+        self.cap.release()
+
+_streams: dict[int, CameraStream] = {}
+
+
+def get_stream(cam_index: int = 0,
+               res: tuple[int, int] | None = (1600, 1200),
+               warm: int = 10) -> CameraStream:
+    """Return a running CameraStream for the given index."""
+    stream = _streams.get(cam_index)
+    if stream is None:
+        stream = CameraStream(cam_index, res=res, warm=warm)
+        _streams[cam_index] = stream
+    return stream

--- a/camera/camera_w_calibration.py
+++ b/camera/camera_w_calibration.py
@@ -13,6 +13,7 @@ camera_color_baseline.py  —  Baseline Color Calibration Pipeline
 # ssh -i C:\Users\shich\.ssh\ot2_ssh_key root@172.26.192.201
 from __future__ import annotations
 import cv2, time, json, os, argparse
+from .camera_stream import get_stream
 import numpy as np
 from pathlib import Path
 import sys
@@ -50,30 +51,11 @@ class PlateProcessor:
     def snapshot(cam: int = 0, path: str = "camera/snapshot.jpg",
                  warm: int = 10, burst: int = 5,
                  res: tuple[int, int] | None = (1600, 1200)) -> str:
-        """Capture a denoised snapshot (burst average)."""
-        cap = cv2.VideoCapture(cam, cv2.CAP_DSHOW)
-        if not cap.isOpened():
-            raise RuntimeError("Camera open failed")
-        if res:                          # set resolution before warm-up
-            w, h = res
-            cap.set(3, w)
-            cap.set(4, h)
-            time.sleep(0.2)
-
-        print("Warming up camera...")
-        for _ in range(warm):            # let exposure settle
-            cap.read()
-            time.sleep(0.04)
-
-        acc = None
-        print("Capturing burst...")
-        for _ in range(burst):
-            _, frm = cap.read()
-            acc = frm.astype(np.float32) if acc is None else acc + frm
-            time.sleep(0.02)
-        cap.release()
-
-        img = (acc / burst).astype(np.uint8)
+        """Return the latest frame captured by a background thread."""
+        stream = get_stream(cam_index=cam, res=res, warm=warm)
+        img = stream.read()
+        if img is None:
+            raise RuntimeError("No frame captured")
         Path(path).parent.mkdir(parents=True, exist_ok=True)
         cv2.imwrite(path, img, [cv2.IMWRITE_JPEG_QUALITY, 95])
         return path


### PR DESCRIPTION
## Summary
- add a `CameraStream` helper that constantly captures frames in a thread
- update snapshot functions in `camera_w_calibration` and `dual_camera_w_calibration` to pull the latest frame instead of taking a burst

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d4025a3ec832bb822cf166324a558