### PR TITLE
Add auto-discovery for Go executable AIs

### DIFF
--- a/battleship/ai/go_wrapper.py
+++ b/battleship/ai/go_wrapper.py
@@ -2,7 +2,7 @@ import json
 import os
 import subprocess
 import tempfile
-from typing import Tuple, Dict, Any
+from typing import Tuple, Dict, Any, Optional
 import tkinter as tk
 from tkinter import filedialog
 
@@ -13,13 +13,21 @@ from battleship.plate_state_processor import WellState
 class GoWrapperAI(BattleshipAI):
     """A Battleship AI that delegates move selection to a Go executable."""
 
-    def __init__(self, player_id: str, board_shape: Tuple[int, int], ship_schema: Dict[str, Any]) -> None:
+    def __init__(
+        self,
+        player_id: str,
+        board_shape: Tuple[int, int],
+        ship_schema: Dict[str, Any],
+        go_executable: Optional[str] = None,
+    ) -> None:
         super().__init__(player_id, board_shape, ship_schema)
-        # Open a file dialog to select the Go executable
-        root = tk.Tk()
-        root.withdraw()  # Hide the main window
-        self.go_executable = filedialog.askopenfilename(title="Select Go Executable")
-        root.destroy()
+        if go_executable is None:
+            # Open a file dialog to select the Go executable
+            root = tk.Tk()
+            root.withdraw()  # Hide the main window
+            go_executable = filedialog.askopenfilename(title="Select Go Executable")
+            root.destroy()
+        self.go_executable = go_executable
 
     def select_next_move(self) -> Tuple[int, int]:
         board = [[cell.value for cell in row] for row in self.board_state]

--- a/battleship/placement_ai/__init__.py
+++ b/battleship/placement_ai/__init__.py
@@ -1,9 +1,11 @@
 from .base_placement_ai import PlacementAI
 from .naive_placement_ai import NaivePlacementAI
 from .random_placement_ai import RandomPlacementAI
+from .go_wrapper import GoPlacementWrapperAI
 
 __all__ = [
     'PlacementAI',
     'NaivePlacementAI',
     'RandomPlacementAI',
+    'GoPlacementWrapperAI',
 ]

--- a/battleship/placement_ai/go_wrapper.py
+++ b/battleship/placement_ai/go_wrapper.py
@@ -1,0 +1,38 @@
+import json
+import os
+import subprocess
+import tempfile
+from typing import Dict, Any, List, Tuple, Optional
+import tkinter as tk
+from tkinter import filedialog
+
+from .base_placement_ai import PlacementAI
+
+
+class GoPlacementWrapperAI(PlacementAI):
+    """Placement AI that delegates placement generation to a Go executable."""
+
+    def __init__(
+        self,
+        board_shape: Tuple[int, int],
+        ship_schema: Dict[str, Any],
+        go_executable: Optional[str] = None,
+    ) -> None:
+        super().__init__(board_shape, ship_schema)
+        if go_executable is None:
+            root = tk.Tk()
+            root.withdraw()
+            go_executable = filedialog.askopenfilename(title="Select Go Placement Executable")
+            root.destroy()
+        self.go_executable = go_executable
+
+    def generate_placement(self) -> List[Dict[str, Any]]:
+        data = {"board_shape": self.board_shape, "ship_schema": self.ship_schema}
+        with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
+            json.dump(data, tmp)
+            tmp_path = tmp.name
+        try:
+            result = subprocess.run([self.go_executable, tmp_path], capture_output=True, text=True, check=True)
+            return json.loads(result.stdout)
+        finally:
+            os.remove(tmp_path)


### PR DESCRIPTION
## Summary
- allow GoWrapperAI to accept executable path at init
- discover `.exe` gameplay AIs in `go_ais` and wrap them automatically
- add GoPlacementWrapperAI for placement AIs
- discover placement executables
- expose new placement AI in `__init__`
- keep placeholder directory for placement executables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d4141cfa8832b9539053fcd222622